### PR TITLE
feat(api)!: add goal route

### DIFF
--- a/packages/multiply-backend/src/interfaces/GoalRepositoryInterface.py
+++ b/packages/multiply-backend/src/interfaces/GoalRepositoryInterface.py
@@ -1,0 +1,17 @@
+
+from abc import ABC, abstractmethod
+from typing import Optional, Dict
+from src.models import Goal
+
+class GoalRepositoryInterface(ABC):
+    @abstractmethod
+    def save(self, goal: Goal) -> None:
+        pass
+
+    @abstractmethod
+    def find_by_id(self, goal_id: str) -> Optional[Goal]:
+        pass
+
+    @abstractmethod
+    def update(self, goal_id: str, updates: Dict) -> Optional[Goal]:
+        pass

--- a/packages/multiply-backend/src/interfaces/GoalServiceInterface.py
+++ b/packages/multiply-backend/src/interfaces/GoalServiceInterface.py
@@ -1,0 +1,17 @@
+
+from abc import ABC, abstractmethod
+from typing import Optional, Dict
+from src.models import Goal
+
+class GoalServiceInterface(ABC):
+    @abstractmethod
+    def create_goal(self, goal_data: Goal) -> Goal:
+        pass
+
+    @abstractmethod
+    def update_goal(self, goal_id: str, updates: Dict) -> Goal:
+        pass
+
+    @abstractmethod
+    def get_goal(self, goal_id: str) -> Goal:
+        pass

--- a/packages/multiply-backend/src/models/Goal.py
+++ b/packages/multiply-backend/src/models/Goal.py
@@ -1,0 +1,22 @@
+import datetime as dt
+from pydantic import Field, BaseModel, validator
+import uuid
+
+ALLOWED_GOAL_TYPES = {'WEDDING', 'HOMEBUYING', 'NEW_CAR', 'CUSTOM'}
+
+class Goal(BaseModel):
+    goal_id: str = Field(default_factory=lambda: str(uuid.uuid4()), alias='goalId')
+    user_id: str = Field(..., alias='userId')
+    goal_type: str = Field(..., alias='goalType')
+    target_amount: float = Field(default=0.00, alias='targetAmount')
+
+    class Config:
+        populate_by_name = True
+        allow_population_by_alias = True
+        arbitrary_types_allowed = True
+
+    @validator('goal_type')
+    def validate_goal_type(cls, value):
+        if value not in ALLOWED_GOAL_TYPES:
+            raise ValueError(f"Invalid goalType. Allowed types are {ALLOWED_GOAL_TYPES}.")
+        return value

--- a/packages/multiply-backend/src/repositories/GoalRepository.py
+++ b/packages/multiply-backend/src/repositories/GoalRepository.py
@@ -1,0 +1,29 @@
+from threading import Lock
+from typing import Optional, Dict
+from src.models.Goal import Goal
+from src.utils.storage import GOAL_STORE
+from src.interfaces.GoalRepositoryInterface import GoalRepositoryInterface
+
+class GoalRepository(GoalRepositoryInterface):
+    _lock = Lock()
+
+    def save(self, goal: Goal) -> None:
+        with self._lock:
+            GOAL_STORE[goal.goal_id] = goal
+
+    def find_by_id(self, goal_id: str) -> Optional[Goal]:
+        with self._lock:
+            return GOAL_STORE.get(goal_id)
+
+    def update(self, goal_id: str, updates: Dict) -> Optional[Goal]:
+        with self._lock:
+            goal = GOAL_STORE.get(goal_id)
+
+            if goal:
+                data = goal.dict(by_alias=True)
+                # Merge updates
+                data.update(updates)
+                updated_goal = Goal(**data)
+                GOAL_STORE[goal_id] = updated_goal
+                return updated_goal
+            return None

--- a/packages/multiply-backend/src/routes/GoalRoutes.py
+++ b/packages/multiply-backend/src/routes/GoalRoutes.py
@@ -1,0 +1,54 @@
+from flask import Blueprint, jsonify, request
+
+from dataclasses import asdict
+
+from src.models.Goal import Goal
+
+from src.services.GoalService import GoalService
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+goalRoutes = Blueprint('goalRoutes', __name__, url_prefix='/goal')
+
+goalService = GoalService()
+
+@goalRoutes.route('', methods=['POST'])
+def createGoal():
+    try:
+        data = request.get_json()
+        goalData = Goal(**data)
+
+        goalService = GoalService()
+
+        goal = goalService.create_goal(goalData)
+        return jsonify({'goalId': goal.goal_id}), 201
+    except Exception as e:
+        logger.exception("Unhandled exception in createGoal.")
+        return jsonify({'error': 'An internal error occurred.'}), 500
+    
+@goalRoutes.route('/<goalId>', methods=['GET'])
+def get_goal(goalId):
+    try:
+        goal = goalService.get_goal(goalId)
+        return jsonify(goal.model_dump(by_alias=True)), 200
+
+    except Exception as e:
+        logger.exception("Unhandled exception in get_goal.")
+        return jsonify({'error': 'An internal error occurred.'}), 500
+    
+@goalRoutes.route('/update/<goalId>', methods=['PUT', 'PATCH'])
+def updateGoal(goalId):
+    try:
+        updates = request.get_json()
+        if not updates:
+            logger.warning("Invalid or missing JSON body.")
+            return jsonify({'error': 'Invalid or missing JSON body.'}), 400
+            
+        goal = goalService.update_goal(goalId, updates)
+        return jsonify({'goalId': goal.goal_id}), 200
+
+    except Exception as e:
+        logger.exception("Unhandled exception in update_goal.")
+        return jsonify({'error': 'An internal error occurred.'}), 500

--- a/packages/multiply-backend/src/routes/__init__.py
+++ b/packages/multiply-backend/src/routes/__init__.py
@@ -1,5 +1,7 @@
 from flask import Flask
 from src.routes.UserRoutes import userRoutes
+from src.routes.GoalRoutes import goalRoutes
 
 def registerRoutes(app: Flask):
     app.register_blueprint(userRoutes)
+    app.register_blueprint(goalRoutes)

--- a/packages/multiply-backend/src/services/GoalService.py
+++ b/packages/multiply-backend/src/services/GoalService.py
@@ -1,0 +1,40 @@
+import logging
+from typing import Dict
+from src.models import Goal
+from src.repositories.GoalRepository import GoalRepository
+from src.repositories.UserRepository import UserRepository
+from src.interfaces import GoalServiceInterface, GoalRepositoryInterface, UserRepositoryInterface
+from src.interfaces.GoalServiceInterface import GoalServiceInterface
+from src.interfaces.GoalRepositoryInterface import GoalRepositoryInterface
+from src.interfaces.UserRepositoryInterface import UserRepositoryInterface
+
+logger = logging.getLogger(__name__)
+
+class GoalService(GoalServiceInterface):
+    def __init__(self, goal_repo: GoalRepositoryInterface = GoalRepository(), user_repo: UserRepositoryInterface = UserRepository()):
+        self.goal_repo = goal_repo
+        self.user_repo = user_repo
+
+    def create_goal(self, goal_data: Goal) -> Goal:
+        if not self.user_repo.findById(goal_data.user_id):
+            logger.warning(f"Attempt to create goal for non-existent user ID: {goal_data.user_id}")
+            raise Exception("User not found.")
+        self.goal_repo.save(goal_data)
+        logger.info(f"Goal created with ID: {goal_data.goal_id}")
+        return goal_data
+
+    def update_goal(self, goal_id: str, updates: Dict) -> Goal:
+        goal = self.goal_repo.update(goal_id, updates)
+        if not goal:
+            logger.warning(f"Attempt to update non-existent goal ID: {goal_id}")
+            raise Exception("Goal not found.")
+        logger.info(f"Goal updated with ID: {goal.goal_id}")
+        return goal
+
+    def get_goal(self, goal_id: str) -> Goal:
+        goal = self.goal_repo.find_by_id(goal_id)
+        if not goal:
+            logger.warning(f"Attempt to retrieve non-existent goal ID: {goal_id}")
+            raise Exception("Goal not found.")
+        logger.info(f"Goal retrieved with ID: {goal.goal_id}")
+        return goal

--- a/packages/multiply-backend/tests/test_api.py
+++ b/packages/multiply-backend/tests/test_api.py
@@ -14,3 +14,69 @@ def test_createUser(client):
     assert response.status_code == 201
     data = response.get_json()
     assert 'userId' in data
+
+def test_create_user_existing_email(client):
+    # Create first user
+    client.post('/user', json={
+        'firstName': 'Jan',
+        'email': 'jan@multiply.ai'
+    })
+    # Attempt to create second user with same email
+    response = client.post('/user', json={
+        'firstName': 'Jan',
+        'email': 'jan@multiply.ai'
+    })
+    assert response.status_code == 400
+    data = response.get_json()
+    assert 'error' in data
+    assert data['error'] == 'Email already registered'
+
+def test_create_goal(client):
+    response = client.post('/goal', json={
+        'goalType': 'WEDDING',
+        'targetAmount': 100.00
+    })
+    assert response.status_code == 201
+    data = response.get_json()
+    assert 'goalId' in data
+
+def test_update_goal(client):
+    # Create a goal first
+    create_response = client.post('/goal', json={
+        'goalType': 'NEW_CAR',
+        'targetAmount': 15000.00
+    })
+    goal_id = create_response.get_json()['goalId']
+
+    # Update the goal
+    update_response = client.post('/goal', json={
+        'goalId': goal_id,
+        'targetAmount': 20000.00
+    })
+    assert update_response.status_code == 200
+    data = update_response.get_json()
+    assert 'goalId' in data
+    assert data['goalId'] == goal_id
+
+def test_get_goal(client):
+    # Create a goal first
+    create_response = client.post('/goal', json={
+        'goalType': 'HOMEBUYING',
+        'targetAmount': 300000.00
+    })
+    goal_id = create_response.get_json()['goalId']
+
+    # Retrieve the goal
+    get_response = client.get('/goal', json={'goalId': goal_id})
+    assert get_response.status_code == 200
+    goal_data = get_response.get_json()
+    assert goal_data['goal_id'] == goal_id
+    assert goal_data['goal_type'] == 'HOMEBUYING'
+    assert goal_data['target_amount'] == 300000.00
+
+def test_get_goal_not_found(client):
+    response = client.get('/goal', json={'goalId': 'nonexistent-id'})
+    assert response.status_code == 404
+    data = response.get_json()
+    assert 'error' in data
+    assert data['error'] == 'Goal not found'


### PR DESCRIPTION
<!--
Please ensure that you complete the following mandatory sections:

- Issue*
- Overview
- Reason*

* Only mandatory if working from a issue with a User Story
-->

## 🚀 Overview

<!-- [A summary of what you did in no more than one paragraph] -->
- Adds Goal model
- Adds Goal routes
- Adds Goal respository and service

## 🤔 Reason
- `POST` requests sent to the `/goal` route should create and persist or update one or more fields. We would also like the response to indicate the `goal_id` for the Goal you have created/updated. Note that the list of possible requests above is not exhaustive. Think about all the different types of requests that we would like to `POST` to the `/goal` route.
- `GET` requests sent to the `/goal` route should return all the fields for a particular goal.
- The possible goal types your API should be prepared to handle are `WEDDING`, `HOMEBUYING`, `NEW_CAR` and `CUSTOM`

<!-- [Why did you do what you did? - This should be copied from the User Story part of the issue if it is available] -->

## 🖥️ Screenshot

<!-- [If the work is UI related then paste a screenshot of the update here. Where possible, please use an animated screenshot.] -->

## 📝 Developer Notes

<!-- [Sometimes, extra notes are needed to add clarity to a PR, add them here] -->